### PR TITLE
Adding after_failure procedure to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,8 @@ env:
     - ARTIFACTORY_URL=https://mifos.jfrog.io/mifos
     - ARTIFACTORY_USER=travis-ci
     - secure: "NHjl/OM08+Q8zRXH1GRowPmFTCarpZVgpfzvW23DnHI9kwPcAuvXHUs0liBD1FgUr3oFNlIQ8QknlWSAb2yI9CTs/+v6f7wl4t4Xx4t5gV0wFuffb3W7a41bE+m1OSUunleSGLKr4qGffjPQ63EUyAb4wrywg23iY12OHbQ3a988UvqoDg6IjK7NXKeLhkAXg6qLDRh9aHdM6NknFNUUIbYyX25PMTQj/SShDQ3xptOhrj1wOvKbBEBc2t2X4+0/3pKt36W0VwJt68HPL4YKwFNiErqSXDAmKFwcf/aZxlXAGreCYN9rNuGuP5RMpblY1bNi6sW2COG0IgTjNSvQgULfIb42GI68O9w0supKZ8OKQLnDJDIQ5q1A1rE54bqs1ey8WD9bmwc24NTUkmjKTqDMTMqCLE+gXLM7xnS2JNisOETfEfRughUFBvmHVPgnQ6fCDJ0brPWBO9Se/elPP/XWlWAkdXsynrRueGCuhplUg1dQhrWm6zSLX5VDeaqQ1vbiU5y3QpAYjJUV/HLk3J8v3Lgv4maUWzyr1Law8K9pAPMcTA2UZR6NsrgWTAsV2mSuRc+Xyf1aGpMqNMaqOHlvfJuY6DobJxdy62LjgF4ovQNY8lVSp5aVDs4TAAQBvMlyVKfJyNJLGuPOjdYkjidm9lWxjX81Y4t1Yg4khL4="
+
+after_failure:
+  - ./gradlew rat
+  - cat api/build/reports/rat/rat-report.txt
+

--- a/shared.gradle
+++ b/shared.gradle
@@ -19,25 +19,25 @@ group 'org.apache.fineract.cn.notification'
 version '0.1.0-BUILD-SNAPSHOT'
 
 ext.versions = [
-        fineractcnidentity      : '0.1.0-BUILD-SNAPSHOT',
-        fineractcnoffice        : '0.1.0-BUILD-SNAPSHOT',
-        fineractcncustomer      : '0.1.0-BUILD-SNAPSHOT',
-        fineractcnaccounting    : '0.1.0-BUILD-SNAPSHOT',
-        fineractcnportfolio     : '0.1.0-BUILD-SNAPSHOT',
-        fineractcnteller        : '0.1.0-BUILD-SNAPSHOT',
-        fineractcnpayroll       : '0.1.0-BUILD-SNAPSHOT',
-        fineractcngroup         : '0.1.0-BUILD-SNAPSHOT',
-        frameworkapi            : '0.1.0-BUILD-SNAPSHOT',
-        frameworklang           : '0.1.0-BUILD-SNAPSHOT',
-        frameworkasync          : '0.1.0-BUILD-SNAPSHOT',
-        frameworkcassandra      : '0.1.0-BUILD-SNAPSHOT',
-        frameworkmariadb        : '0.1.0-BUILD-SNAPSHOT',
-        frameworkcommand        : '0.1.0-BUILD-SNAPSHOT',
-        frameworktest           : '0.1.0-BUILD-SNAPSHOT',
-        frameworkanubis         : '0.1.0-BUILD-SNAPSHOT',
-        validator               : '5.3.0.Final',
-        springjavamail          : '1.4.1.RELEASE',
-        twilioapi               : '7.17.+'
+        fineractcnidentity  : '0.1.0-BUILD-SNAPSHOT',
+        fineractcnoffice    : '0.1.0-BUILD-SNAPSHOT',
+        fineractcncustomer  : '0.1.0-BUILD-SNAPSHOT',
+        fineractcnaccounting: '0.1.0-BUILD-SNAPSHOT',
+        fineractcnportfolio : '0.1.0-BUILD-SNAPSHOT',
+        fineractcnteller    : '0.1.0-BUILD-SNAPSHOT',
+        fineractcnpayroll   : '0.1.0-BUILD-SNAPSHOT',
+        fineractcngroup     : '0.1.0-BUILD-SNAPSHOT',
+        frameworkapi        : '0.1.0-BUILD-SNAPSHOT',
+        frameworklang       : '0.1.0-BUILD-SNAPSHOT',
+        frameworkasync      : '0.1.0-BUILD-SNAPSHOT',
+        frameworkcassandra  : '0.1.0-BUILD-SNAPSHOT',
+        frameworkmariadb    : '0.1.0-BUILD-SNAPSHOT',
+        frameworkcommand    : '0.1.0-BUILD-SNAPSHOT',
+        frameworktest       : '0.1.0-BUILD-SNAPSHOT',
+        frameworkanubis     : '0.1.0-BUILD-SNAPSHOT',
+        validator           : '5.3.0.Final',
+        springjavamail      : '1.4.1.RELEASE',
+        twilioapi           : '7.17.+'
 ]
 
 apply plugin: 'java'
@@ -94,11 +94,11 @@ artifactory {
         }
 
         defaults {
-            publications ('api', 'componentTest', 'service', 'bootService')
+            publications('api', 'componentTest', 'service', 'bootService')
         }
     }
 }
-artifactoryPublish.dependsOn('clean','publishToMavenLocal')
+artifactoryPublish.dependsOn('clean', 'publishToMavenLocal')
 
 license {
     header rootProject.file('../HEADER')
@@ -122,5 +122,6 @@ rat {
             "gradlew.bat",
             "README.md"
     ]
+    plainOutput = true
 }
 


### PR DESCRIPTION
The build outputs compilations error hence, it will not be necessary to output every log (component-test, service or api), however, no details are given for rat failures.

This will allow developers to view the report.